### PR TITLE
feat: add option to include deno.json file

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ prompts.
 ## Quickstart
 
 ```bash
-deno install --allow-read --allow-run=git --allow-write --unstable -n deno-init https://deno.land/x/init@1.1.0/mod.ts
+deno install --allow-read --allow-run=git --allow-write --unstable -n deno-init https://deno.land/x/init@v1.2.0/mod.ts
 
 deno-init -y -n awesome_deno_project
 ```
@@ -36,7 +36,7 @@ Next, run the `deno install` command below to install the executable:
 <p>
 
 ```bash
-deno install --allow-read --allow-run=git --allow-write --unstable -n deno-init https://deno.land/x/init@1.1.0/mod.ts
+deno install --allow-read --allow-run=git --allow-write --unstable -n deno-init https://deno.land/x/init@v1.2.0/mod.ts
 ```
 
 </p>
@@ -47,7 +47,7 @@ deno install --allow-read --allow-run=git --allow-write --unstable -n deno-init 
 <p>
 
 ```bash
-deno install --allow-read --allow-run=git --allow-write --unstable -n deno-init https://x.nest.land/init@1.1.0/mod.ts
+deno install --allow-read --allow-run=git --allow-write --unstable -n deno-init https://x.nest.land/init@v1.2.0/mod.ts
 ```
 
 </p>
@@ -74,7 +74,8 @@ new version number and include the `-f` flag.
 The program needs the following permissions to run:
 
 - `read`: to load files that are used to initialize projects
-- `run=git`: is used to allow the program to run `git` commands, of which only `git init` is actually called by `deno-init`
+- `run=git`: is used to allow the program to run `git` commands, of which only
+  `git init` is actually called by `deno-init`
 - `write`: to make files in order to initialize new projects
 - `unstable`: to allow the use of unstable APIs. Right now these come from the
   module's external dependencies.

--- a/act.test.ts
+++ b/act.test.ts
@@ -46,6 +46,22 @@ Rhum.testPlan("act.test.ts", () => {
         await act();
       },
     );
+
+    Rhum.testCase(
+      "should create deno.json if setting.config is true",
+      async () => {
+        settings.config = true;
+        settings.map = false;
+        settings.path = "test_directory_act";
+        settings.git = false;
+
+        await act();
+
+        const configFile = await Deno.readFile("./test_directory_act/deno.json");
+
+        Rhum.asserts.assert(configFile);
+      },
+    );
   });
 });
 

--- a/act.ts
+++ b/act.ts
@@ -28,6 +28,13 @@ export async function act() {
     );
   }
 
+  if (settings.config === true) {
+    await writeFileSec(
+      settings.path + "/deno.json",
+      settings.mapContent,
+    );
+  }
+
   if (settings.git === true) {
     await initGit(settings.path);
   }

--- a/egg.json
+++ b/egg.json
@@ -3,7 +3,7 @@
   "entry": "./mod.ts",
   "description": "Simple command line tool to initialize Deno projects from prompts.",
   "unstable": false,
-  "version": "1.1.0",
+  "version": "v1.2.0",
   "files": [
     "./**/*.ts",
     "./README.md",

--- a/init.ts
+++ b/init.ts
@@ -3,13 +3,18 @@ import { act } from "./act.ts";
 import { settings } from "./settings.ts";
 import { hasFileExtension } from "./utils.ts";
 
-/**
- *
- */
+/**/
 await new Command()
   .name("deno-init")
-  .version("1.1.0")
+  .version("v1.2.0")
   .description("Start a new Deno project with a single command")
+  .option(
+    "-c, --config [config:boolean]",
+    "Add a Deno configuration file (JSON) as part of the project.",
+    {
+      default: false,
+    },
+  )
   .option(
     "-f, --force [force:boolean]",
     "Force overwrite of existing files/directories. Helpful to re-initialize a project but use with caution!",
@@ -19,7 +24,7 @@ await new Command()
   )
   .option(
     "-m, --map [map:boolean]",
-    "Add an import map as part of the project initialization",
+    "Add an import map as part of the project",
     {
       default: false,
     },
@@ -33,7 +38,7 @@ await new Command()
   )
   .option(
     "-n, --name [name:string]",
-    "Name a new directory to initialize the project in.",
+    "Create the project in a new directory with the entered name",
     {
       global: true,
     },
@@ -45,7 +50,8 @@ await new Command()
       default: false,
     },
   )
-  .action(({ force, map, git, name, yes }) => {
+  .action(({ config, force, map, git, name, yes }) => {
+    settings.config = config;
     settings.force = force;
     settings.git = git;
     settings.map = map;
@@ -61,7 +67,7 @@ await new Command()
   .parse(Deno.args);
 
 function ask() {
-  const ts = prompt("Use TypeScript? (y/n)", "y");
+  const ts = prompt("Use TypeScript?", "y");
 
   settings.extension = (ts === "y" || ts === "Y") ? "ts" : "js";
 
@@ -82,21 +88,33 @@ function ask() {
 
   if (!settings.map) {
     const importMap = prompt(
-      "Add import map? (y/n)",
+      "Add import map?",
       "n",
     );
     settings.map = (importMap === "y" || importMap === "Y") ? true : false;
   }
 
-  if (!hasFileExtension(settings.entrypoint, settings.extension)) {
+  if (!settings.config) {
+    const config = prompt(
+      "Add Deno configuration file?",
+      "n",
+    );
+    settings.config = (config === "y" || config === "Y") ? true : false;
+  }
+
+  if (hasFileExtension(settings.entrypoint, settings.extension) === false) {
     settings.entrypoint = `${settings.entrypoint}.${settings.extension}`;
   }
 
-  if (!hasFileExtension(settings.depsEntrypoint, settings.extension)) {
-    settings.depsEntrypoint = `${settings.depsEntrypoint}.${settings.extension}`;
+  if (hasFileExtension(settings.depsEntrypoint, settings.extension) === false) {
+    settings.depsEntrypoint =
+      `${settings.depsEntrypoint}.${settings.extension}`;
   }
 
-  if (!hasFileExtension(settings.devDepsEntrypoint, settings.extension)) {
-    settings.devDepsEntrypoint = `${settings.devDepsEntrypoint}.${settings.extension}`;
+  if (
+    hasFileExtension(settings.devDepsEntrypoint, settings.extension) === false
+  ) {
+    settings.devDepsEntrypoint =
+      `${settings.devDepsEntrypoint}.${settings.extension}`;
   }
 }

--- a/settings.ts
+++ b/settings.ts
@@ -1,4 +1,5 @@
 export interface Settings {
+  config: boolean;
   depsEntrypoint: string;
   devDepsEntrypoint: string;
   depsModule: Uint8Array;
@@ -19,6 +20,7 @@ const encoder = new TextEncoder();
 export const defaultModuleContent = encoder.encode("export {};\n");
 
 export const settings: Settings = {
+  config: false,
   extension: "ts",
   entrypoint: "mod.ts",
   depsEntrypoint: "deps.ts",


### PR DESCRIPTION
- Adds the `--config` option to the CLI to enable users to include a `deno.json` config file as part of the initialized project
