### PR TITLE
refactor: clean up unstable flags from deno test and coverage runs

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -17,15 +17,15 @@ jobs:
         with:
           deno-version: v1.x
 
-      - name: Lint
+      - name: Analyze code with Deno linter
         run: deno lint
 
-      - name: Test
+      - name: Run unit tests
         run: |
-          deno test -A --unstable --coverage=./cov
+          deno test -A --coverage=./cov
 
       - name: Generate coverage report
-        run: deno coverage --unstable --lcov ./cov > cov.lcov
+        run: deno coverage --lcov ./cov > cov.lcov
 
       - name: Upload coverage report
         uses: coverallsapp/github-action@master


### PR DESCRIPTION
- Removed unstable flags from `deno test` and `deno coverage` commands in the CI pipeline
