### PR TITLE
chore: improve help visibility on powershell terminals

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ this module is purely for generating config.
 ## Installation
 
 ```
-deno install --allow-read --allow-write -fn deno-init https://deno.land/x/init@v2.1.0/mod.ts
+deno install --allow-read --allow-write -fn deno-init https://deno.land/x/init@v2.1.1/mod.ts
 ```
 
 ## Usage

--- a/egg.json
+++ b/egg.json
@@ -3,7 +3,7 @@
   "entry": "./mod.ts",
   "description": "Generate a Deno configuration file.",
   "unstable": false,
-  "version": "v2.1.0",
+  "version": "v2.1.1",
   "files": [
     "./**/*.ts",
     "./README.md",

--- a/init.ts
+++ b/init.ts
@@ -6,6 +6,9 @@ await new Command()
   .name("deno-init")
   .version("v2.1.0")
   .description("Generate a Deno configuration file.")
+  .help({
+    colors: (Deno.build.os === "windows") ? false : true,
+  })
   .option(
     "-f, --force [force:boolean]",
     "Force overwriting any existing config file.",

--- a/init.ts
+++ b/init.ts
@@ -4,7 +4,7 @@ import { ask } from "./ask.ts";
 
 await new Command()
   .name("deno-init")
-  .version("v2.1.0")
+  .version("v2.1.1")
   .description("Generate a Deno configuration file.")
   .help({
     colors: (Deno.build.os === "windows") ? false : true,


### PR DESCRIPTION
The default coloring of cliffy help pages it not very visible on Powershell, so this disables the colors if on a windows OS