### PR TITLE
feat: add fill option

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -39,7 +39,7 @@ jobs:
           path: ${{ env.DENO_DIR }}
           key: ${{ hashFiles('lock.json') }}
 
-      - run: deno test --allow-read --allow-write --allow-net=deno.land --lock=lock.json --coverage=cov/
+      - run: deno test --allow-read --allow-write --lock=lock.json --coverage=cov/
 
       - if: matrix.os == 'ubuntu-20.04'
         run: deno coverage --lcov --output=cov.lcov cov/

--- a/README.md
+++ b/README.md
@@ -23,13 +23,27 @@ this module is purely for generating config.
 ## Installation
 
 ```
-deno install --allow-read --allow-write --allow-net=deno.land -fn deno-init https://deno.land/x/init@v2.2.0/mod.ts
+deno install --allow-read --allow-write -fn deno-init https://deno.land/x/init@v2.3.0/mod.ts
 ```
 
 ## Usage
 
+Make a config file based on a number of prompts:
+
 ```
 deno-init
+```
+
+Skip the prompts, use all defaults:
+
+```
+deno-init --yes
+```
+
+Add every possible option in comments (as a `.jsonc` file)
+
+```
+deno-init --fill
 ```
 
 ## Options
@@ -43,11 +57,12 @@ working directory with default values:
 deno-init --yes
 ```
 
-`--jsonc` or `-c` will create a `.jsonc` config file with all the possible
-configuration options listed as comments.
+`--fill` or `-i` will create a `deno.jsonc` config file with all the possible
+configuration options listed as comments. This style is very similar to the
+output of `tsc --init` for generating a `tsconfig.json`.
 
 ```
-deno-init --jsonc
+deno-init --fill
 ```
 
 `--fmt` or `-m` will add a `fmt` section only.
@@ -76,6 +91,10 @@ auto-discovery.
 deno-init --name config.json
 ```
 
+`--force` or `-f` will allow overwriting an existing config file.
+
 ## Contributing
 
-Bug reports, other issues or feature requests are welcome!
+You are welcome to report any bugs, other issues, or feature requests! If you
+want to add a fix/feature/other improvement fork this repository and make a pull
+request with your changes.

--- a/egg.json
+++ b/egg.json
@@ -3,7 +3,7 @@
   "entry": "./mod.ts",
   "description": "Generate a Deno configuration file.",
   "unstable": false,
-  "version": "v2.2.0",
+  "version": "v2.3.0",
   "files": [
     "./**/*.ts",
     "./README.md",

--- a/init.ts
+++ b/init.ts
@@ -4,14 +4,18 @@ import { ask } from "./ask.ts";
 
 await new Command()
   .name("deno-init")
-  .version("v2.2.0")
+  .version("v2.3.0")
   .description("Generate a Deno configuration file.")
   .help({
     colors: (Deno.build.os === "windows") ? false : true,
   })
   .option(
-    "-c, --jsonc [jsonc:boolean]",
+    "-a, --fill [fill:boolean]",
     "Create the config file as .jsonc with the possible options listed as comments.",
+  )
+  .option(
+    "-c, --jsonc [jsonc:boolean]",
+    "Create the config file as .jsonc. Alias for --fill.",
   )
   .option(
     "-f, --force [force:boolean]",
@@ -42,7 +46,8 @@ await new Command()
   )
   .action((options) => {
     if (
-      options.yes || options.fmt || options.lint || options.tsconfig ||
+      options.yes || options.fill || options.fmt || options.lint ||
+      options.tsconfig ||
       options.jsonc
     ) {
       inputHandler({ ...defaults, ...options });

--- a/writeConfigFile.ts
+++ b/writeConfigFile.ts
@@ -3,6 +3,7 @@ import { generateJsonc } from "./schema.ts";
 
 export interface Settings {
   force: boolean;
+  fill: boolean;
   fmt: boolean;
   jsonc: boolean;
   lint: boolean;
@@ -13,6 +14,7 @@ export interface Settings {
 
 export const defaults: Settings = {
   force: false,
+  fill: false,
   fmt: false,
   jsonc: false,
   lint: false,
@@ -44,7 +46,7 @@ export type ConfigFile = {
 };
 
 export async function inputHandler(settings: Settings) {
-  if (settings.jsonc) {
+  if (settings.fill || settings.jsonc) {
     settings.name = settings.name.replace(".json", ".jsonc");
 
     return await writeFileSec(


### PR DESCRIPTION
Adds `deno-init --fill` which create `deno.jsonc` with all the possible options listed as comments. Uses a new approach which allows no longer passing `--allow-net=deno.land`.