### PR TITLE
ci: add a type-check step

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -33,6 +33,7 @@ jobs:
 
       - run: deno fmt --check
       - run: deno lint
+      - run: deno check mod.ts
 
       - name: Cache DENO_DIR
         uses: actions/cache@v2


### PR DESCRIPTION
This PR adds a type-check step to the CI to account for the type-checking changes introduced in Deno v1.23