### PR TITLE
feat: support deno test configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,13 @@ requires Deno 1.20 or higher.
 deno-init --task
 ```
 
+`--test` or `-s` will add a `test` section only. Note that using `test`
+requires Deno 1.24 or higher.
+
+```
+deno-init --test
+```
+
 `--tsconfig` or `-t` will add a `compilerOptions` section only.
 
 ```

--- a/README.md
+++ b/README.md
@@ -98,8 +98,8 @@ requires Deno 1.20 or higher.
 deno-init --task
 ```
 
-`--test` or `-s` will add a `test` section only. Note that using `test`
-requires Deno 1.24 or higher.
+`--test` or `-s` will add a `test` section only. Note that using `test` requires
+Deno 1.24 or higher.
 
 ```
 deno-init --test

--- a/__snapshots__/writeConfigFile.test.ts.snap
+++ b/__snapshots__/writeConfigFile.test.ts.snap
@@ -78,7 +78,13 @@ snapshot[`writeConfigFile 3`] = `
   '      // "proseWrap": "always"                 /* Define how prose should be wrapped in Markdown fil...',
   "    }",
   "  },",
-  '  "tasks": {}',
+  '  "tasks": {},',
+  '  "test": {',
+  '    "files": {',
+  '      // "include": []                         /* List of files or directories that will be searched...',
+  '      // "exclude": []                         /* List of files or directories that will not be sear...',
+  "    }",
+  "  }",
   "}",
 ]
 `;
@@ -167,7 +173,26 @@ snapshot[`writeConfigFile 9`] = `
   "    }",
   "  },",
   '  "tasks": {},',
+  '  "test": {',
+  '    "files": {',
+  '      "include": [],',
+  '      "exclude": []',
+  "    }",
+  "  },",
   '  "compilerOptions": {}',
+  "}",
+]
+`;
+
+snapshot[`writeConfigFile 10`] = `
+[
+  "{",
+  '  "test": {',
+  '    "files": {',
+  '      "include": [],',
+  '      "exclude": []',
+  "    }",
+  "  }",
   "}",
 ]
 `;

--- a/deps.ts
+++ b/deps.ts
@@ -1,6 +1,6 @@
 export { Command } from "https://deno.land/x/cliffy@v0.24.2/command/mod.ts";
 export {
   default as schema,
-} from "https://deno.land/x/deno@v1.23.0/cli/schemas/config-file.v1.json" assert {
+} from "https://deno.land/x/deno@v1.24.0/cli/schemas/config-file.v1.json" assert {
   type: "json",
 };

--- a/init.ts
+++ b/init.ts
@@ -42,6 +42,10 @@ await new Command()
     "Set up config for deno tasks only. Requires Deno 1.20 or higher",
   )
   .option(
+    "-s, --test [test:boolean]",
+    "Set up config for deno test only. Requires Deno 1.24 or higher",
+  )
+  .option(
     "-t, --tsconfig [tsconfig:boolean]",
     "Set up config for typescript compiler options only.",
   )

--- a/lock.json
+++ b/lock.json
@@ -73,5 +73,5 @@
   "https://deno.land/x/cliffy@v0.24.2/table/row.ts": "707c8f9c71f28e7ded22a053c13c0988a9598eec0a9e2a7aea7d15cad64d3cfe",
   "https://deno.land/x/cliffy@v0.24.2/table/table.ts": "3905c40d030626faab87a3e2e24982382c0d4c11eccae829a9e04db94d29e3e9",
   "https://deno.land/x/cliffy@v0.24.2/table/utils.ts": "187bb7dcbcfb16199a5d906113f584740901dfca1007400cba0df7dcd341bc29",
-  "https://deno.land/x/deno@v1.23.0/cli/schemas/config-file.v1.json": "bac544c8de59503174db063e95f279fc5b4605dab840fecad3b8a76f5abc3b8e"
+  "https://deno.land/x/deno@v1.24.0/cli/schemas/config-file.v1.json": "af7f9a43f5ac6f97e755debf6ea0996150695c47f1a42a2bccccd50c641d1fbe"
 }

--- a/processOptions.ts
+++ b/processOptions.ts
@@ -4,7 +4,8 @@ import { defaultOpts, type Options } from "./writeConfigFile.ts";
 export function process(opts: Options): Options {
   if (opts.yes) {
     if (
-      opts.tsconfig || opts.fmt || opts.lint || opts.task || opts.map
+      opts.tsconfig || opts.fmt || opts.lint || opts.task || opts.map ||
+      opts.test
     ) {
       throw new Error("--yes cannot be used together with other options.");
     }
@@ -12,7 +13,7 @@ export function process(opts: Options): Options {
 
   if (
     opts.yes || opts.fill || opts.fmt || opts.lint ||
-    opts.tsconfig || opts.jsonc || opts.task || opts.map
+    opts.tsconfig || opts.jsonc || opts.task || opts.map || opts.test
   ) {
     return { ...defaultOpts, ...opts };
   } else {

--- a/promptUserInputs.test.ts
+++ b/promptUserInputs.test.ts
@@ -9,6 +9,7 @@ Deno.test("returns choices collected from user prompts", () => {
     lint: true,
     fmt: true,
     task: true,
+    test: true,
     importMap: false,
     name: "deno.json",
   });

--- a/promptUserInputs.ts
+++ b/promptUserInputs.ts
@@ -40,6 +40,14 @@ export function promptUserInputs(promptOpts: PromptAnswerOptions) {
 
   const fmt = processAnswer(formattingAnswer, defaultOpts.fmt);
 
+  const testingAnswer = promptAnswer(
+    "Would you like to add custom testing configuration? (y/n)",
+    `y`,
+    promptOpts.testmode,
+  );
+
+  const test = processAnswer(testingAnswer, defaultOpts.test);
+
   const taskAnswer = promptAnswer(
     "Would you like to add tasks? (y/n)",
     `y`,
@@ -71,6 +79,7 @@ export function promptUserInputs(promptOpts: PromptAnswerOptions) {
     lint,
     fmt,
     task,
+    test,
     importMap,
     name,
   };

--- a/writeConfigFile.test.ts
+++ b/writeConfigFile.test.ts
@@ -222,4 +222,22 @@ Deno.test("writeConfigFile", async (context) => {
       assert(bytes.length > 0);
     },
   });
+
+  await test({
+    name: "create test",
+    fn: async () => {
+      testOpts.test = true;
+
+      const output = await inputHandler(testOpts);
+
+      const bytes = await Deno.readFile(
+        `${testOpts.name}`,
+      );
+
+      assert(bytes.length > 0);
+      assertEquals(testOpts.name, "deno.json");
+
+      await assertSnapshot(context, output.split("\n"));
+    },
+  });
 });

--- a/writeConfigFile.ts
+++ b/writeConfigFile.ts
@@ -10,6 +10,7 @@ export interface Options {
   map: boolean;
   name: string;
   task: boolean;
+  test: boolean;
   tsconfig: boolean;
   yes: boolean;
 }
@@ -23,6 +24,7 @@ export const defaultOpts: Options = {
   map: false,
   name: "deno.json",
   task: false,
+  test: false,
   tsconfig: false,
   yes: false,
 };
@@ -48,6 +50,12 @@ export type ConfigFile = {
     };
   };
   tasks?: Record<string, unknown>;
+  test?: {
+    files?: {
+      include: string[];
+      exclude: string[];
+    };
+  };
   importMap?: string;
 };
 
@@ -74,6 +82,7 @@ export async function inputHandler(opts: Options) {
     opts.lint = true;
     opts.tsconfig = true;
     opts.task = true;
+    opts.test = true;
   }
 
   if (opts.fmt) {
@@ -106,6 +115,15 @@ export async function inputHandler(opts: Options) {
 
   if (opts.task) {
     configFile.tasks = {};
+  }
+
+  if (opts.test) {
+    configFile.test = {
+      files: {
+        include: [],
+        exclude: [],
+      },
+    };
   }
 
   if (opts.tsconfig) {


### PR DESCRIPTION
Add support for the `test` field in the deno config file that was released in Deno v1.24